### PR TITLE
Proposed Role changes

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,9 +1,19 @@
 Will all go through my Spotify Account
 1. User Accounts Plan
-
- - Admin User -> Can modify play queue, Can skip tracks, Can Approve/Disprove songs?, Can pick playlist to play from when we run out of songs
- - Trusted User -> Can modify play queue, Can skip tracks
- - Un-authenticated User -> Can add tracks to play queue
+ - Admin User (authenticated) -> 
+     - Can add or remove Host Users
+     - All priviliges of Host User
+ - Host User (authenticated) -> 
+     - Can Approve/Disprove songs?
+     - Can pick playlist to play from when we run out of songs
+     - Can add or remove Trusted Users?
+     - All priviliges of Trusted User
+ - Trusted User (authenticated) -> 
+     - Can modify play queue
+     - Can skip tracks
+     - All priviliges of Guest User
+ - Guest User (authenticated/unauthenticated) ->
+     - Can add tracks to play queue
  
  2. Layout Plan
  


### PR DESCRIPTION
### Proposing different role structure:
- Added "Host User" as a level below "Admin User" (Admin being account owner, Host being a close friend/roommate/etc. with admin privileges)
- Changed unauthed user to be "Guest User" that has limited priviliges but can be either authed or unauthed, just not a trusted friend (cause there's a difference)

### Thinking out loud:
- Should we think at scale? e.g.
    - Prepare to have it be installable on anyone's raspberry pi? (admin page for setting up main account, so not hard-coded to @nab0310 Spotify account)
    - Ability to request role promotion through app rather than only verbally, to streamline the role process and aid these additional role tiers
    - Maybe think about somehow linking different music streaming services (e.g. Napster, Amazon Music, Apple Music, YouTube Music, etc.)
- Will the host site use location or a party ID to discern what party you're at? 
    - How will people connect to a local Raspberry PI?
    - Will it be a registered public domain? You have a lot of ComS buddies, we'll need some top notch private server security. Especially if we market this as a DIY party mixer app
